### PR TITLE
Add support to store and retrieve file descriptors in the service manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ Or install it yourself as:
 SystemdDaemon::Notify.ready
 ```
 
+### Notify with fds
+```ruby
+read_fd, write_fd = IO.pipe
+state = {
+  FDSTORE: 1,
+  FDNAME: pid
+}
+SystemdDaemon::Notify.notify_with_fds(0, state, read_fd.to_i)
+```
+
+### Listen fds with names
+```ruby
+fds_hash = SystemdDaemon::Notify.listen_fds_with_names
+# fds_hash = {"5304"=>3, "5301"=>4, "5298"=>5, "5295"=>6}
+```
+
+
 ## Contributing
 
 1. Fork it ( https://github.com/ctrochalakis/systemd-daemon/fork )

--- a/ext/systemd-daemon/systemd-daemon.c
+++ b/ext/systemd-daemon/systemd-daemon.c
@@ -16,6 +16,39 @@ static VALUE _sd_notify(VALUE mod, VALUE unset_env, VALUE state)
   return INT2FIX(return_code);
 }
 
+/* Supports only one fd per call */
+static VALUE _sd_pid_notify_with_fds(VALUE mod, VALUE pid, VALUE unset_env, VALUE state, VALUE fd)
+{
+  const char *sd_state;
+  int return_code;
+  int fd_ref = FIX2INT(fd);
+
+  sd_state = StringValuePtr(state);
+
+  return_code = sd_pid_notify_with_fds(FIX2INT(pid), FIX2INT(unset_env), sd_state, &fd_ref, 1);
+
+  return INT2FIX(return_code);
+}
+
+static VALUE _sd_listen_fds_with_names(VALUE mod, VALUE unset_env)
+{
+  char **fd_names = NULL;
+  int i, fds_size;
+  VALUE result;
+
+  fds_size = sd_listen_fds_with_names(FIX2INT(unset_env), &fd_names);
+  if (fds_size < 0)
+    rb_raise(rb_eRuntimeError, "Failed to get listening fds: %d", fds_size);
+
+  result = rb_hash_new();
+  for (i = 0; i < fds_size; i++)
+    rb_hash_aset(result, rb_str_new_cstr(fd_names[i]), INT2FIX(SD_LISTEN_FDS_START + i));
+
+  free(fd_names);
+
+  return result;
+}
+
 static VALUE _sd_watchdog_enabled(VALUE mod, VALUE unset_env)
 {
   uint64_t period;
@@ -47,9 +80,13 @@ void Init_sd_native()
   VALUE mSDNotify = rb_define_module_under(mSD, "Notify");
 #ifdef HAVE_SYSTEMD_SD_DAEMON_H
   rb_define_singleton_method(mSDNotify, "_sd_notify", _sd_notify, 2);
+  rb_define_singleton_method(mSDNotify, "_sd_pid_notify_with_fds", _sd_pid_notify_with_fds, 4);
+  rb_define_singleton_method(mSDNotify, "_sd_listen_fds_with_names", _sd_listen_fds_with_names, 1);
   rb_define_singleton_method(mSDNotify, "_sd_watchdog_enabled", _sd_watchdog_enabled, 1);
 #else
   rb_define_singleton_method(mSDNotify, "_sd_notify", _not_implemented, -2);
+  rb_define_singleton_method(mSDNotify, "_sd_pid_notify_with_fds", _not_implemented, -2);
+  rb_define_singleton_method(mSDNotify, "_sd_listen_fds_with_names", _not_implemented, -2);
   rb_define_singleton_method(mSDNotify, "_sd_watchdog_enabled", _not_implemented, -2);
 #endif
 }

--- a/lib/systemd-daemon/notify.rb
+++ b/lib/systemd-daemon/notify.rb
@@ -10,6 +10,14 @@ module SystemdDaemon
       _sd_notify(unset_env_value(unset_env), hash_to_sd_state(state))
     end
 
+    def notify_with_fds(pid, state, fd, unset_env=false)
+      _sd_pid_notify_with_fds(pid, unset_env_value(unset_env), hash_to_sd_state(state), fd)
+    end
+
+    def listen_fds_with_names(unset_env=false)
+      _sd_listen_fds_with_names(unset_env_value(unset_env))
+    end
+
     def watchdog_timer(unset_env=false)
       _sd_watchdog_enabled(unset_env_value(unset_env))
     end

--- a/test/test_notify.rb
+++ b/test/test_notify.rb
@@ -55,4 +55,23 @@ class TestSystemdDaemonNotify < Test::Unit::TestCase
       assert_equal true, SystemdDaemon::Notify.watchdog?
     }
   end
+
+  def test_listen_fds_with_names
+    expected_names = { "bar" => 4, "foo" => 3 }
+    with_env('LISTEN_FDNAMES' => expected_names.keys.reverse.join(':'),
+             'LISTEN_FDS' => expected_names.size,
+             'LISTEN_PID' => $$) {
+      assert_equal expected_names, SystemdDaemon::Notify.listen_fds_with_names
+    }
+  end
+
+  def test_notify_with_fds
+    assert_socket("FDSTORE=1\nFDNAME=test") {
+      pid = 0
+      fd  = 3
+      state = { FDSTORE: 1, FDNAME: 'test' }
+
+      SystemdDaemon::Notify.notify_with_fds(pid, state, fd)
+    }
+  end
 end


### PR DESCRIPTION
Adds the bindings for sd_pid_notify_with_fds and sd_listen_fds_with_names
functions.

`notify_with_fds` method can send a file descriptor with a name to
service manager to store and to pass it to the main process again on next
invocation.

sample use:
```
  read_fd, write_fd = IO.pipe
  state = {
    FDSTORE: 1,
    FDNAME: pid
  }
  SystemdDaemon::Notify.notify_with_fds(0, state, read_fd.to_i)
```

`listen_fds_with_names` method checks if there are any file descriptors
passed and if there are, it returns a hash with their names as keys and
their descriptors as values.

sample use:
```
  fds_hash = SystemdDaemon::Notify.listen_fds_with_names
  # fds_hash = {"5304"=>3, "5301"=>4, "5298"=>5, "5295"=>6}
```

For more details you can check [sd_notify(3)](https://www.freedesktop.org/software/systemd/man/sd_notify.html) and [sd_listen_fds(3)](https://www.freedesktop.org/software/systemd/man/sd_listen_fds.html).