### PR TITLE
Add support to store and retrieve file descriptors in the service manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,38 @@ Or install it yourself as:
 SystemdDaemon::Notify.ready
 ```
 
+### Notify with fds
+Sending one fd
+```ruby
+read_fd, write_fd = IO.pipe
+state = {
+  FDSTORE: 1,
+  FDNAME: pid
+}
+SystemdDaemon::Notify.notify_with_fds(0, state, read_fd.to_i)
+```
+
+Sending an array of fds
+```ruby
+read_fd1, write_fd1 = IO.pipe
+read_fd2, write_fd2 = IO.pipe
+
+fds = [read_fd1.to_i, read_fd2.to_i]
+state = {
+  FDSTORE: 1,
+  FDNAME: "testgroup"
+}
+
+SystemdDaemon::Notify.notify_with_fds(0, state, fds)
+```
+
+### Listen fds with names
+```ruby
+fds_hash = SystemdDaemon::Notify.listen_fds_with_names
+# fds_hash = {"listening_socket_a"=>3, "listening_socket_b"=>4, "listening_socket_c"=>5}
+```
+
+
 ## Contributing
 
 1. Fork it ( https://github.com/ctrochalakis/systemd-daemon/fork )

--- a/ext/systemd-daemon/extconf.rb
+++ b/ext/systemd-daemon/extconf.rb
@@ -16,5 +16,7 @@ asplode('libsystemd/libsystemd-daemon') if !have_library('systemd') && !have_lib
 asplode('sd_notify') if not have_func('sd_notify', 'systemd/sd-daemon.h')
 
 have_func('sd_watchdog_enabled')
+have_func('sd_pid_notify_with_fds')
+have_func('sd_listen_fds_with_names')
 
 create_makefile('systemd-daemon/sd_native')

--- a/ext/systemd-daemon/systemd-daemon.c
+++ b/ext/systemd-daemon/systemd-daemon.c
@@ -16,6 +16,54 @@ static VALUE _sd_notify(VALUE mod, VALUE unset_env, VALUE state)
   return INT2FIX(return_code);
 }
 
+static VALUE _sd_pid_notify_with_fds(VALUE mod, VALUE pid, VALUE unset_env, VALUE state, VALUE fds)
+{
+  int i, return_code;
+
+#ifdef HAVE_SD_PID_NOTIFY_WITH_FDS
+  const char *sd_state;
+  int size = RARRAY_LEN(fds);
+  int *fds_ref = (int *)malloc(size * sizeof(int));
+  pid_t target_pid = FIXNUM_P(pid) ? NUM2PIDT(pid) : 0;
+
+  sd_state = StringValuePtr(state);
+  for(i = 0; i < size; i ++)
+    fds_ref[i] = FIX2INT(rb_ary_entry(fds, i));
+  return_code = sd_pid_notify_with_fds(target_pid, FIX2INT(unset_env), sd_state, fds_ref, size);
+
+  free(fds_ref);
+#else
+  /* Indicates that the fds were not send. As when $NOTIFY_SOCKET is not set,
+   * no status message could be sent and 0 is returned.
+  */
+  return_code = 0;
+#endif
+  return INT2FIX(return_code);
+}
+
+static VALUE _sd_listen_fds_with_names(VALUE mod, VALUE unset_env)
+{
+  char **fd_names = NULL;
+  int i, fds_size;
+  VALUE result;
+#ifdef HAVE_SD_LISTEN_FDS_WITH_NAMES
+  fds_size = sd_listen_fds_with_names(FIX2INT(unset_env), &fd_names);
+  if (fds_size < 0)
+    rb_raise(rb_eRuntimeError, "Failed to get listening fds: %d", fds_size);
+
+  result = rb_hash_new();
+  for (i = 0; i < fds_size; i++)
+    rb_hash_aset(result, rb_str_new_cstr(fd_names[i]), INT2FIX(SD_LISTEN_FDS_START + i));
+
+  free(fd_names);
+#else
+  /* Returns an empty hash if sd_listen_fds_with_names is not part of the current API */
+  result = rb_hash_new();
+#endif
+
+  return result;
+}
+
 static VALUE _sd_watchdog_enabled(VALUE mod, VALUE unset_env)
 {
   uint64_t period;
@@ -47,9 +95,13 @@ void Init_sd_native()
   VALUE mSDNotify = rb_define_module_under(mSD, "Notify");
 #ifdef HAVE_SYSTEMD_SD_DAEMON_H
   rb_define_singleton_method(mSDNotify, "_sd_notify", _sd_notify, 2);
+  rb_define_singleton_method(mSDNotify, "_sd_pid_notify_with_fds", _sd_pid_notify_with_fds, 4);
+  rb_define_singleton_method(mSDNotify, "_sd_listen_fds_with_names", _sd_listen_fds_with_names, 1);
   rb_define_singleton_method(mSDNotify, "_sd_watchdog_enabled", _sd_watchdog_enabled, 1);
 #else
   rb_define_singleton_method(mSDNotify, "_sd_notify", _not_implemented, -2);
+  rb_define_singleton_method(mSDNotify, "_sd_pid_notify_with_fds", _not_implemented, -2);
+  rb_define_singleton_method(mSDNotify, "_sd_listen_fds_with_names", _not_implemented, -2);
   rb_define_singleton_method(mSDNotify, "_sd_watchdog_enabled", _not_implemented, -2);
 #endif
 }

--- a/lib/systemd-daemon/notify.rb
+++ b/lib/systemd-daemon/notify.rb
@@ -10,6 +10,16 @@ module SystemdDaemon
       _sd_notify(unset_env_value(unset_env), hash_to_sd_state(state))
     end
 
+    def notify_with_fds(pid, state, fds, unset_env=false)
+      fds_array = [fds].flatten    # Ensure that the fds will be an array
+
+      _sd_pid_notify_with_fds(pid, unset_env_value(unset_env), hash_to_sd_state(state), fds_array)
+    end
+
+    def listen_fds_with_names(unset_env=false)
+      _sd_listen_fds_with_names(unset_env_value(unset_env))
+    end
+
     def watchdog_timer(unset_env=false)
       _sd_watchdog_enabled(unset_env_value(unset_env))
     end

--- a/test/test_notify.rb
+++ b/test/test_notify.rb
@@ -55,4 +55,34 @@ class TestSystemdDaemonNotify < Test::Unit::TestCase
       assert_equal true, SystemdDaemon::Notify.watchdog?
     }
   end
+
+  def test_listen_fds_with_names
+    fds_with_names = { "foo" => 3, "bar" => 4 }
+
+    with_env('LISTEN_FDNAMES' => fds_with_names.keys.join(":"),
+             'LISTEN_FDS' => fds_with_names.size,
+             'LISTEN_PID' => $$) {
+      assert_equal fds_with_names, SystemdDaemon::Notify.listen_fds_with_names
+    }
+  end
+
+  def test_notify_with_one_fd
+    assert_socket("FDSTORE=1\nFDNAME=test") {
+      pid = 0
+      fd  = 3
+      state = { FDSTORE: 1, FDNAME: 'test' }
+
+      SystemdDaemon::Notify.notify_with_fds(pid, state, fd)
+    }
+  end
+
+  def test_notify_with_fds
+    assert_socket("FDSTORE=1\nFDNAME=testgroup") {
+      pid = 0
+      fd  = [3, 4]
+      state = { FDSTORE: 1, FDNAME: 'testgroup' }
+
+      SystemdDaemon::Notify.notify_with_fds(pid, state, fd)
+    }
+  end
 end


### PR DESCRIPTION
Adds the bindings for sd_pid_notify_with_fds and sd_listen_fds_with_names
functions.

`notify_with_fds` method can send one or more file descriptors with their
names, to service manager to store and pass to the main process again on
next invocation.

sample use:
```
  read_fd, write_fd = IO.pipe
  state = {
    FDSTORE: 1,
    FDNAME: pid
  }
  SystemdDaemon::Notify.notify_with_fds(0, state, read_fd.to_i)
```

`listen_fds_with_names` method checks if there are any file descriptors
passed and if there are, it returns a hash with their names as keys and
their descriptors as values.

sample use:
```
  fds_hash = SystemdDaemon::Notify.listen_fds_with_names
  # fds_hash = {"pid342"=>3, "pid221"=>4, "pid351"=>5, "pid154"=>6}
```

For more details you can check sd_notify(3) and sd_listen_fds(3).